### PR TITLE
Update link for slim template

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ It also takes a block for inline templates (see [example](#inline-templates)).
 <table>
   <tr>
     <td>Dependency</td>
-    <td><a href="http://slim-lang.com/" title="Slim Lang">Slim Lang</a></td>
+    <td><a href="https://slim-template.github.io/" title="Slim Lang">Slim Lang</a></td>
   </tr>
   <tr>
     <td>File Extension</td>


### PR DESCRIPTION
This PR updated the old dead link for slim template website to its new github pages website.